### PR TITLE
Add recoil-like cross-app observation

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -3,8 +3,8 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { RoomServiceProvider, useMap, usePresence } from '../.';
 
-const MapDemo = () => {
-  const [map, setMap] = useMap<any>('room', 'map');
+function Input(props: { name: string; map: string }) {
+  const [map, setMap] = useMap<any>('room', props.map);
   if (!map) return null;
 
   function onChange(key, e) {
@@ -13,11 +13,26 @@ const MapDemo = () => {
   }
 
   return (
+    <input
+      value={map.get(props.name) || ''}
+      onChange={e => onChange(props.name, e)}
+    />
+  );
+}
+
+const MapDemo = () => {
+  return (
     <div>
       <label>
-        A <input value={map.get('a') || ''} onChange={e => onChange('a', e)} />
-        B <input value={map.get('b') || ''} onChange={e => onChange('b', e)} />
-        C <input value={map.get('c') || ''} onChange={e => onChange('c', e)} />
+        <p>
+          A <Input name="a" map="first" />
+        </p>
+        <p>
+          B <Input name="b" map="second" />
+        </p>
+        <p>
+          A <Input name="a" map="first" />
+        </p>
       </label>
     </div>
   );

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -5,6 +5,8 @@ import { RoomServiceProvider, useMap, usePresence } from '../.';
 
 function Input(props: { name: string; map: string }) {
   const [map, setMap] = useMap<any>('room', props.map);
+  const rerenders = React.useRef(0);
+  rerenders.current++;
   if (!map) return null;
 
   function onChange(key, e) {
@@ -13,10 +15,13 @@ function Input(props: { name: string; map: string }) {
   }
 
   return (
-    <input
-      value={map.get(props.name) || ''}
-      onChange={e => onChange(props.name, e)}
-    />
+    <>
+      <input
+        value={map.get(props.name) || ''}
+        onChange={e => onChange(props.name, e)}
+      />{' '}
+      {rerenders.current}
+    </>
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "@roomservice/browser": "2.1.2"
+    "@roomservice/browser": "2.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.2",
+  "version": "0.10.0-0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/RoomServiceProvider.tsx
+++ b/src/RoomServiceProvider.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { ClientProvider } from './contextForClient';
+import { SubscriptionProvider } from './contextForSubscriptions';
+import { RoomServiceParameters } from '@roomservice/browser';
+
+export function RoomServiceProvider(props: {
+  children: React.ReactNode;
+  clientParameters: RoomServiceParameters;
+}) {
+  return (
+    <SubscriptionProvider>
+      <ClientProvider clientParameters={props.clientParameters}>
+        {props.children}
+      </ClientProvider>
+    </SubscriptionProvider>
+  );
+}

--- a/src/contextForClient.tsx
+++ b/src/contextForClient.tsx
@@ -1,16 +1,18 @@
 import * as React from 'react';
-import { RoomClient, RoomService } from '@roomservice/browser';
+import {
+  RoomClient,
+  RoomService,
+  RoomServiceParameters,
+} from '@roomservice/browser';
 import { createContext, ReactNode, useRef } from 'react';
-import { RoomServiceParameters } from '@roomservice/browser/dist/RoomServiceClient';
 
-interface RoomServiceContext {
+interface ClientContext {
   addRoom?: (key: string) => Promise<RoomClient>;
 }
 
-export const context = createContext<RoomServiceContext>({
-});
+export const clientContext = createContext<ClientContext>({});
 
-export function RoomServiceProvider({
+export function ClientProvider({
   children,
   clientParameters,
 }: {
@@ -32,12 +34,12 @@ export function RoomServiceProvider({
   }
 
   return (
-    <context.Provider
+    <clientContext.Provider
       value={{
         addRoom,
       }}
     >
       {children}
-    </context.Provider>
+    </clientContext.Provider>
   );
 }

--- a/src/contextForSubscriptions.tsx
+++ b/src/contextForSubscriptions.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { useRef, createContext, useContext } from 'react';
+
+interface SubscriptionContext {
+  subscribe: (event: string, callback: (arg: any) => any) => any;
+  publish: (event: string, data: any) => any;
+}
+
+export const subscriptionContext = createContext<SubscriptionContext>(
+  {} as any
+);
+
+export function useLocalPubSub() {
+  return useContext(subscriptionContext);
+}
+
+export function SubscriptionProvider(props: { children: React.ReactNode }) {
+  const ref = useRef<any>({
+    subs: {},
+  });
+
+  function subscribe(event: string, callback: Function) {
+    if (!Array.isArray(ref.current.subs[event])) {
+      ref.current!.subs[event] = [];
+    }
+    ref.current!.subs[event].push(callback);
+  }
+
+  function publish(event: string, data: any) {
+    if (!Array.isArray(ref.current.subs[event])) return;
+    for (let fn of ref.current.subs[event]) fn(data);
+  }
+
+  return (
+    <subscriptionContext.Provider value={{ subscribe, publish }}>
+      {props.children}
+    </subscriptionContext.Provider>
+  );
+}

--- a/src/errors.tsx
+++ b/src/errors.tsx
@@ -1,0 +1,8 @@
+/**
+ * Occurs if the programmer uses a hook in a component that doesn't
+ * have the RoomServiceProvider as an ancestor.
+ */
+export const errOutsideOfProvider = () =>
+  new Error(
+    'A hook is being used outside the RoomServiceProvider. Learn more: https://err.sh/getroomservice/react/no-provider'
+  );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,4 +2,4 @@ export { usePresence } from './usePresence';
 export { useMap } from './useMap';
 export { useList } from './useList';
 export { useRoom } from './useRoom';
-export { RoomServiceProvider } from './context';
+export { RoomServiceProvider } from './RoomServiceProvider';

--- a/src/useList.tsx
+++ b/src/useList.tsx
@@ -1,6 +1,7 @@
 import { useRoom } from './useRoom';
 import { ListClient } from '@roomservice/browser';
 import { useState, useEffect } from 'react';
+import { useLocalPubSub } from './contextForSubscriptions';
 
 export function useList<T extends any>(
   roomName: string,
@@ -8,6 +9,8 @@ export function useList<T extends any>(
 ): [ListClient<T> | undefined, (list: ListClient<T>) => any] {
   const [list, setList] = useState<ListClient<T>>();
   const room = useRoom(roomName);
+  const local = useLocalPubSub();
+  const key = roomName + listName;
 
   useEffect(() => {
     if (!room) return;
@@ -18,7 +21,16 @@ export function useList<T extends any>(
     room.subscribe(l, next => {
       setList(next);
     });
+
+    local.subscribe(key, list => {
+      setList(list);
+    });
   }, [room, listName]);
 
-  return [list, setList];
+  function setAndBroadcastList(list: ListClient<T>) {
+    setList(list);
+    local.publish(key, list);
+  }
+
+  return [list, setAndBroadcastList];
 }

--- a/src/useList.tsx
+++ b/src/useList.tsx
@@ -1,7 +1,7 @@
 import { useRoom } from './useRoom';
 import { ListClient } from '@roomservice/browser';
 import { useState, useEffect } from 'react';
-import { useLocalPubSub } from './contextForSubscriptions';
+import { useLocalPubSub, useSelf } from './contextForSubscriptions';
 
 export function useList<T extends any>(
   roomName: string,
@@ -9,8 +9,9 @@ export function useList<T extends any>(
 ): [ListClient<T> | undefined, (list: ListClient<T>) => any] {
   const [list, setList] = useState<ListClient<T>>();
   const room = useRoom(roomName);
+  const self = useSelf();
   const local = useLocalPubSub();
-  const key = roomName + listName;
+  const key = 'l' + roomName + listName;
 
   useEffect(() => {
     if (!room) return;
@@ -22,14 +23,14 @@ export function useList<T extends any>(
       setList(next);
     });
 
-    local.subscribe(key, list => {
+    local.subscribe(self, key, list => {
       setList(list);
     });
   }, [room, listName]);
 
   function setAndBroadcastList(list: ListClient<T>) {
     setList(list);
-    local.publish(key, list);
+    local.publish(self, key, list);
   }
 
   return [list, setAndBroadcastList];

--- a/src/useMap.tsx
+++ b/src/useMap.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { MapClient } from '@roomservice/browser';
 import { useRoom } from './useRoom';
-import { useLocalPubSub } from './contextForSubscriptions';
+import { useLocalPubSub, useSelf } from './contextForSubscriptions';
 
 export function useMap<T extends any>(
   roomName: string,
@@ -9,8 +9,9 @@ export function useMap<T extends any>(
 ): [MapClient<T> | undefined, (map: MapClient<T>) => any] {
   const [map, setMap] = useState<MapClient<T>>();
   const room = useRoom(roomName);
+  const self = useSelf();
   const local = useLocalPubSub();
-  const key = roomName + mapName;
+  const key = 'm' + roomName + mapName;
 
   useEffect(() => {
     if (!room) return;
@@ -22,14 +23,14 @@ export function useMap<T extends any>(
       setMap(next);
     });
 
-    local.subscribe(key, list => {
+    local.subscribe(self, key, list => {
       setMap(list);
     });
   }, [room, mapName]);
 
   function setAndBroadcast(map: MapClient<T>) {
     setMap(map);
-    local.publish(key, map);
+    local.publish(self, key, map);
   }
 
   return [map, setAndBroadcast];

--- a/src/usePresence.tsx
+++ b/src/usePresence.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { PresenceClient } from '@roomservice/browser';
 import { useRoom } from './useRoom';
-import { useLocalPubSub } from './contextForSubscriptions';
+import { useLocalPubSub, useSelf } from './contextForSubscriptions';
 
 export function usePresence<T extends any>(
   roomName: string,
@@ -10,8 +10,9 @@ export function usePresence<T extends any>(
   const presence = useRef<PresenceClient>();
   const [val, setVal] = useState<{ [key: string]: T }>({});
   const room = useRoom(roomName);
+  const self = useSelf();
   const local = useLocalPubSub();
-  const localKey = roomName + key;
+  const localKey = 'p' + roomName + key;
 
   useEffect(() => {
     if (!room) return;
@@ -27,7 +28,7 @@ export function usePresence<T extends any>(
       setVal(val);
     });
 
-    local.subscribe(localKey, val => {
+    local.subscribe(self, localKey, val => {
       setVal(val);
     });
   }, [room, key]);
@@ -36,7 +37,7 @@ export function usePresence<T extends any>(
   const set = useCallback((value: T) => {
     if (!presence.current) return;
     presence.current?.set(key, value);
-    local.publish(localKey, value);
+    local.publish(self, localKey, value);
   }, []);
 
   return [val, set];

--- a/src/useRoom.tsx
+++ b/src/useRoom.tsx
@@ -1,13 +1,12 @@
 import { useContext, useEffect, useState } from 'react';
 import { RoomClient } from '@roomservice/browser';
-import { context } from './context';
+import { clientContext } from './contextForClient';
+import { errOutsideOfProvider } from './errors';
 
 export function useRoom(roomName: string): RoomClient | undefined {
-  const ctx = useContext(context);
+  const ctx = useContext(clientContext);
   if (!ctx.addRoom) {
-    throw new Error(
-      'A hook is being used outside the RoomServiceProvider. Learn more: https://err.sh/getroomservice/react/no-provider'
-    );
+    throw errOutsideOfProvider();
   }
   const [room, setRoom] = useState<RoomClient>();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1139,10 +1139,10 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@roomservice/browser@2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@roomservice/browser/-/browser-2.1.2.tgz#054651a0de960a7b302f2134dd16c8e66117cbc9"
-  integrity sha512-MBNZjsRPCRe3u5R0fwe0O2Iivtiqz4iCKR2PQCpRdr3DNB+a5mYGDPzsydwW8sxlvb3nXA/PnM1xC+Y2d4dVcw==
+"@roomservice/browser@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@roomservice/browser/-/browser-2.1.3.tgz#529e86cf6fbb6fca0b46e7ec45be9d76a8c3aaf0"
+  integrity sha512-KpDJAlSTqnQKIXDfKn2u64AQwlYbTzLkhigU7gYXfprtr1pt0gD/fewxOwJEeFirhYX51PlkQ0au5l+vcprP4g==
   dependencies:
     tiny-invariant "^1.1.0"
 


### PR DESCRIPTION
# Overview

This PR adds the ability for two components to listen to the same hook (`useMap`, `useList`, or `usePresence`) and receive updates from one another. 

If you update something in one component, it appears in the other:

```jsx
function Alice() {
  const [map, setMap] = useMap("room", "coolmap")
  // ...
  setMap(map.set("pet", "dog"))
}

function Berry() {
  const [map, setMap] = useMap("room", "coolmap")
  // ...
  map.get("pet") // "dog"
}
```

## Performance

Normally if you want two components to share state, you have to hoist the state up to a parent. If you want it to be globally available, you'd put a `useState` in the [context](https://reactjs.org/docs/context.html) API. The downside of this is that every change rerenders the _entire_ component tree:

```jsx
function NormalContextAPI() {
  return ( 
    <SadProvider>
      <ListenToXYZ /> {/* rerenders! */}
      <ListenToXYZ /> {/* rerenders! */}
      <ListenToSomethingElse /> {/* rerenders! */}
    </SadProvider>
  )
}
```

Room Service only rerenders the individual components that have updated:
```jsx
function RoomServiceContextAPI() {
  return ( 
    <RoomServiceProvider>
      <ListenToXYZ /> {/* rerenders! */}
      <ListenToXYZ /> {/* rerenders! */}
      <ListenToSomethingElse /> {/* Does not rerender! */}
    </RoomServiceProvider>
  )
}
```

## FAQ 

### How does this fit in with Recoil?

This adds the same performance benefit and usability you'd get with Recoil natively within Room Service. At the moment, Recoil doesn't play nicely with Room Service (it errors on Javascript classes, which messes with some of Room Service's built-in optimizations). 

You're still good to use Recoil in the rest of your app though, or for things like names of rooms, maps, or lists. 