### PR TITLE
allow passing 'Offline' as parameters to delay auth

### DIFF
--- a/src/RoomServiceProvider.tsx
+++ b/src/RoomServiceProvider.tsx
@@ -5,9 +5,16 @@ import { RoomServiceParameters } from '@roomservice/browser';
 export function RoomServiceProvider(props: {
   children: React.ReactNode;
   clientParameters: RoomServiceParameters<any>;
+  //  Whether to authenticate and connect to RoomService infrastructure. Can be
+  //  initially set to false to delay authentication until the user is logged in.
+  //  Defaults to true.
+  online?: boolean;
 }) {
   return (
-    <ClientProvider clientParameters={props.clientParameters}>
+    <ClientProvider
+      clientParameters={props.clientParameters}
+      online={props.online}
+    >
       {props.children}
     </ClientProvider>
   );

--- a/src/contextForClient.tsx
+++ b/src/contextForClient.tsx
@@ -15,19 +15,37 @@ export const clientContext = createContext<ClientContext>({});
 export function ClientProvider({
   children,
   clientParameters,
+  online,
 }: {
   children: ReactNode;
   clientParameters: RoomServiceParameters<any>;
+  online?: boolean;
 }) {
-  const rs = new RoomService(clientParameters);
+  const rs = useRef<RoomService<any> | undefined>();
+
+  const delayedInitClientTriggers = useRef<Array<() => void>>([]);
+  if (online === undefined || online === true) {
+    rs.current = new RoomService(clientParameters);
+    for (const trigger of delayedInitClientTriggers.current) {
+      trigger();
+    }
+    delayedInitClientTriggers.current = [];
+  }
+
   // ref instead of state here to prevent a double render
   //  and allow delayed initialization
   const pendingRef = useRef<{ [key: string]: Promise<RoomClient> }>({});
 
-  async function addRoom(key: string) {
+  async function addRoom(key: string): Promise<RoomClient> {
     //  Make sure rs.room is only ever called once per room
     if (!pendingRef.current[key]) {
-      pendingRef.current[key] = rs.room(key);
+      if (rs.current === undefined) {
+        const { trigger, promise } = triggeredPromise();
+        delayedInitClientTriggers.current.push(trigger);
+        pendingRef.current[key] = promise.then(() => rs.current!.room(key));
+      } else {
+        pendingRef.current[key] = rs.current.room(key);
+      }
     }
     const room = await pendingRef.current[key];
     return room;
@@ -42,4 +60,16 @@ export function ClientProvider({
       {children}
     </clientContext.Provider>
   );
+}
+
+function triggeredPromise(): {
+  trigger: () => void;
+  promise: Promise<void>;
+} {
+  let trigger: (_: any) => void;
+  const triggerPromise = new Promise<void>(resolve => {
+    trigger = resolve;
+  });
+
+  return { trigger: trigger! as () => void, promise: triggerPromise };
 }


### PR DESCRIPTION
supports logging in later in a react application

tested with a simple _app.tsx change:
```
import { RoomServiceProvider } from "@roomservice/react";
import { useEffect, useState } from "react";

function MyApp({ Component, pageProps }) {
  const [loggedIn, setLoggedIn] = useState(false);
  useEffect(() => {
    setTimeout(() => {
      setLoggedIn(true);
    }, 5000);
  }, []);
  return (
    <RoomServiceProvider
      clientParameters={loggedIn ? { auth: "/api/roomservice" } : "Offline"}
    >
      <Component {...pageProps} />
    </RoomServiceProvider>
  );
}

export default MyApp;
```